### PR TITLE
Add simple repair request web app

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,11 +1,38 @@
 <!DOCTYPE html>
+<html lang="th">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>ระบบแจ้งซ่อม</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>แบบฟอร์มแจ้งซ่อม</h1>
+  <form id="repair-form">
+    <label for="name">ชื่อผู้แจ้ง</label>
+    <input type="text" id="name" required>
 
-<html>
-   <head>
-      <base target="_top">
-      <meta name="viewport" content="width=device-width, initial-scale=1">      
-   </head>
-   <body>
-      <iframe style="position: absolute;top: 0;left: 0;width: 100%;height: 100%;border: 0;" src="https://script.google.com/macros/s/AKfycbwcWTSDT7XhOhpetQIY7G5cPX51dKLqx03FkOCArsU-mLzn1S7kIs-iQqJmZtq3xOhCLw/exec"></iframe>
-   </body>
+    <label for="email">อีเมล</label>
+    <input type="email" id="email" required>
+
+    <label for="issue">รายละเอียดปัญหา</label>
+    <textarea id="issue" required></textarea>
+
+    <button type="submit">ส่ง</button>
+  </form>
+
+  <h2>รายการแจ้งซ่อมก่อนหน้า</h2>
+  <table id="request-table">
+    <thead>
+      <tr>
+        <th>ผู้แจ้ง</th>
+        <th>อีเมล</th>
+        <th>รายละเอียด</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <script src="script.js"></script>
+</body>
 </html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "repair-app",
+  "version": "1.0.0",
+  "description": "Simple repair request web app",
+  "scripts": {
+    "test": "echo \"No tests specified\""
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,28 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const form = document.getElementById('repair-form');
+  const tableBody = document.querySelector('#request-table tbody');
+  const requests = JSON.parse(localStorage.getItem('requests') || '[]');
+
+  function render() {
+    tableBody.innerHTML = '';
+    requests.forEach(r => {
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${r.name}</td><td>${r.email}</td><td>${r.issue}</td>`;
+      tableBody.appendChild(row);
+    });
+  }
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const name = document.getElementById('name').value.trim();
+    const email = document.getElementById('email').value.trim();
+    const issue = document.getElementById('issue').value.trim();
+    if (!name || !email || !issue) return;
+    requests.push({ name, email, issue, time: Date.now() });
+    localStorage.setItem('requests', JSON.stringify(requests));
+    form.reset();
+    render();
+  });
+
+  render();
+});

--- a/style.css
+++ b/style.css
@@ -1,0 +1,34 @@
+body {
+  font-family: sans-serif;
+  margin: 20px;
+  background: #f5f5f5;
+}
+form {
+  display: flex;
+  flex-direction: column;
+  max-width: 400px;
+  gap: 10px;
+}
+input, textarea {
+  padding: 8px;
+  font-size: 1em;
+}
+button {
+  padding: 10px;
+  background: #007bff;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+table {
+  margin-top: 20px;
+  border-collapse: collapse;
+  width: 100%;
+}
+th, td {
+  border: 1px solid #ccc;
+  padding: 8px;
+}
+th {
+  background: #eee;
+}


### PR DESCRIPTION
## Summary
- build basic repair form UI and table
- add client-side logic to store and display requests via localStorage
- add basic styling and npm metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6894146f653083219624fadaaa125b4c